### PR TITLE
keywordselect, flowerkeywordmapping 엔티티 추가

### DIFF
--- a/src/main/java/org/flower/entities/Flower.java
+++ b/src/main/java/org/flower/entities/Flower.java
@@ -12,8 +12,8 @@ import org.flower.commons.constants.UserRole;
 @NoArgsConstructor      // 파라미터가 없는 기본 생성자를 생성
 @AllArgsConstructor     // 모든 필드를 파라미터로 갖는 생성자를 생성
 @Entity                 // 이 클래스가 JPA 엔티티임을 나타낸다. 즉 이 클래스의 인스턴스들은 데이터베이스의 레코드와 매핑된다.
-@Table(name="flowerinfo")    // 'name' 속성으로 해당 엔티티가 매핑될 테이블의 이름을 지정함
-public class Flower extends BaseEntity{
+@Table(name="flowers")    // 'flowers' 속성으로 해당 엔티티가 매핑될 테이블의 이름을 지정함
+public class Flower {
     /*
      * @ID
      * 'flowerNo' 필드가 이 엔티티의 기본 키임을 나타낸다.

--- a/src/main/java/org/flower/entities/FlowerKeywordMapping.java
+++ b/src/main/java/org/flower/entities/FlowerKeywordMapping.java
@@ -1,0 +1,24 @@
+package org.flower.entities;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@ToString(exclude = {"flower", "keyword"})
+@EqualsAndHashCode(exclude = {"flower", "keyword"})
+@Table(name="mapping") // 'mapping' 속성으로 해당 엔티티가 매핑될 테이블의 이름을 지정
+public class FlowerKeywordMapping {
+
+    @Id
+    private Long id;
+
+    @ManyToOne
+    private Flower flower;
+
+    @ManyToOne
+    private Keywords keyword;
+
+    private Integer weight;
+}

--- a/src/main/java/org/flower/entities/KeywordSelect.java
+++ b/src/main/java/org/flower/entities/KeywordSelect.java
@@ -1,0 +1,30 @@
+package org.flower.entities;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@ToString(exclude = {"user", "keyword"})
+@EqualsAndHashCode(exclude = {"user","keyword"})
+@Table(name="keywordselect")  // 'keywordselect' 속성으로 해당 엔티티가 매핑될 테이블의 이름을 지정
+public class KeywordSelect {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long SelectionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userNo")
+    private User user;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keywordNo")
+    private Keywords keyword;
+
+    @Column(name = "weight", columnDefinition = "INT DEFAULT 0")
+    private int weight;
+
+}

--- a/src/main/java/org/flower/entities/Keywords.java
+++ b/src/main/java/org/flower/entities/Keywords.java
@@ -12,8 +12,8 @@ import org.flower.commons.constants.UserRole;
 @NoArgsConstructor      // 파라미터가 없는 기본 생성자를 생성
 @AllArgsConstructor     // 모든 필드를 파라미터로 갖는 생성자를 생성
 @Entity                 // 이 클래스가 JPA 엔티티임을 나타낸다. 즉 이 클래스의 인스턴스들은 데이터베이스의 레코드와 매핑된다.
-@Table(name="keywords")    // 'name' 속성으로 해당 엔티티가 매핑될 테이블의 이름을 지정함
-public class Keywords extends BaseEntity{
+@Table(name="keywords")    // 'keywords' 속성으로 해당 엔티티가 매핑될 테이블의 이름을 지정
+public class Keywords {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
keywordselect 엔티티는 사용자가 선택한 키워드와 가중치를 저장하고, 가중치를 0으로 설정함으로써 후순위의 가중치들은 행렬 계산에 0이 될 수 있도록 한다. 
flowerkeywordmapping 엔티티는 꽃과 키워드 간의 가중치를 담고 있는 테이블로 각 꽃마다의 가중치 값을 저장해놓는다. 